### PR TITLE
Split tests

### DIFF
--- a/.github/workflows/github_tests.yml
+++ b/.github/workflows/github_tests.yml
@@ -42,11 +42,8 @@ jobs:
 #      with:
 #        github-token: ${{ secrets.GITHUB_TOKEN }}
 #        path-to-lcov: "coverage.lcov"
-  tests-functional:
+  simulate-data:
     runs-on: ubuntu-latest
-    defaults:
-      run:
-        shell: bash -l {0}
 
     steps:
     - name: Checkout Repo
@@ -65,7 +62,15 @@ jobs:
         pip install -e .
     - name: Simulate reads
       run: |
-        marbel --n-species 10 --n-orthogroups 200 --n-samples 5 10 --outdir run_spec10_orth200_samp5-10/
+        marbel --n-species 10 --n-orthogroups 20 --n-samples 2 4 --library-size 5000 --outdir run_spec10_orth200_samp5-10/
+
+  tests-functional:
+    needs: simulate-data
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        shell: bash -l {0}
+
     - name: Create conda test-env
       run: |
         conda create -n marbel-tests scikit-bio

--- a/.github/workflows/github_tests.yml
+++ b/.github/workflows/github_tests.yml
@@ -89,6 +89,9 @@ jobs:
       uses: actions/download-artifact@v4
       with:
         name: simulated data
+    - name: debug
+      run: |
+        ls -latr
     - name: Execute functional tests
       run: |
         conda init

--- a/.github/workflows/github_tests.yml
+++ b/.github/workflows/github_tests.yml
@@ -62,7 +62,7 @@ jobs:
         pip install -e .
     - name: Simulate reads
       run: |
-        marbel --n-species 10 --n-orthogroups 20 --n-samples 2 4 --library-size 5000 --outdir run_spec10_orth200_samp5-10/
+        marbel --n-species 10 --n-orthogroups 200 --n-samples 5 10 --outdir run_spec10_orth200_samp5-10/
     - name: Archive simulation results
       uses: actions/upload-artifact@v4
       with:
@@ -90,9 +90,6 @@ jobs:
       with:
         name: simulated data
         path: run_spec10_orth200_samp5-10/
-    - name: debug
-      run: |
-        ls -latr
     - name: Execute functional tests
       run: |
         conda init

--- a/.github/workflows/github_tests.yml
+++ b/.github/workflows/github_tests.yml
@@ -63,6 +63,12 @@ jobs:
     - name: Simulate reads
       run: |
         marbel --n-species 10 --n-orthogroups 20 --n-samples 2 4 --library-size 5000 --outdir run_spec10_orth200_samp5-10/
+    - name: Archive simulation results
+        uses: actions/upload-artifact@v4
+        with:
+          name: simulated data
+          path: run_spec10_orth200_samp5-10
+
 
   tests-functional:
     needs: simulate-data
@@ -72,10 +78,17 @@ jobs:
         shell: bash -l {0}
 
     steps:
+    - name: Checkout Repo
+      uses: actions/checkout@v2
+      with:
+          lfs: true
     - name: Create conda test-env
       run: |
         conda create -n marbel-tests scikit-bio
-
+    - name: Download simulated data
+      uses: actions/download-artifact@v4
+      with:
+        name: simulated data
     - name: Execute functional tests
       run: |
         conda init

--- a/.github/workflows/github_tests.yml
+++ b/.github/workflows/github_tests.yml
@@ -64,10 +64,10 @@ jobs:
       run: |
         marbel --n-species 10 --n-orthogroups 20 --n-samples 2 4 --library-size 5000 --outdir run_spec10_orth200_samp5-10/
     - name: Archive simulation results
-        uses: actions/upload-artifact@v4
-        with:
-          name: simulated data
-          path: run_spec10_orth200_samp5-10
+      uses: actions/upload-artifact@v4
+      with:
+        name: simulated data
+        path: run_spec10_orth200_samp5-10
 
 
   tests-functional:

--- a/.github/workflows/github_tests.yml
+++ b/.github/workflows/github_tests.yml
@@ -71,6 +71,7 @@ jobs:
       run:
         shell: bash -l {0}
 
+    steps:
     - name: Create conda test-env
       run: |
         conda create -n marbel-tests scikit-bio

--- a/.github/workflows/github_tests.yml
+++ b/.github/workflows/github_tests.yml
@@ -89,6 +89,7 @@ jobs:
       uses: actions/download-artifact@v4
       with:
         name: simulated data
+        path: run_spec10_orth200_samp5-10/
     - name: debug
       run: |
         ls -latr


### PR DESCRIPTION
This PR splits the processes of generating simulation data and testing it into two jobs. Data are exchanged through an artifact (https://docs.github.com/de/actions/managing-workflow-runs-and-deployments/managing-workflow-runs/removing-workflow-artifacts) and can also be downloaded for local inspection